### PR TITLE
Fix: Corregir el comportamiento del menú en la vista móvil

### DIFF
--- a/alquileres-app/package-lock.json
+++ b/alquileres-app/package-lock.json
@@ -22,6 +22,7 @@
         "@capacitor/keyboard": "6.0.1",
         "@capacitor/status-bar": "6.0.0",
         "@ionic/angular": "^8.0.0",
+        "@ionic/core": "^8.3.4",
         "date-fns": "2.16.1",
         "dayjs": "^1.11.13",
         "ionicons": "^7.0.0",
@@ -3501,6 +3502,17 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@ionic/angular/node_modules/@ionic/core": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-8.2.4.tgz",
+      "integrity": "sha512-lCsPzSEVs/XQMF25/phHlwhDNUlz4gqotzY/fEbhq2PT6Z5w81NndRAPsLQ4JM2k4N2gjJNeUFZJi+W78z2qtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@stencil/core": "^4.19.1",
+        "ionicons": "^7.2.2",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@ionic/cli-framework-output": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/@ionic/cli-framework-output/-/cli-framework-output-2.2.8.tgz",
@@ -3516,11 +3528,12 @@
       }
     },
     "node_modules/@ionic/core": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-8.2.4.tgz",
-      "integrity": "sha512-lCsPzSEVs/XQMF25/phHlwhDNUlz4gqotzY/fEbhq2PT6Z5w81NndRAPsLQ4JM2k4N2gjJNeUFZJi+W78z2qtA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-8.4.0.tgz",
+      "integrity": "sha512-mZ2Ni9QByFGWBNr5W/F/nyPV+cXLhK+6W5BRziy7QPX6YIS57KH8FpY+CjE7BEcpE78anyY49bZt3eOWcES02g==",
+      "license": "MIT",
       "dependencies": {
-        "@stencil/core": "^4.19.1",
+        "@stencil/core": "4.20.0",
         "ionicons": "^7.2.2",
         "tslib": "^2.1.0"
       }
@@ -5075,9 +5088,10 @@
       "dev": true
     },
     "node_modules/@stencil/core": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.1.tgz",
-      "integrity": "sha512-fjSBctHrobeSL2+XcuX7GVk/eaUhZ/lvIu21RJmzHAPcNyueuSAEv7J/Isn4UlYNk70o+yOK72H0FTlNkUibvw==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.20.0.tgz",
+      "integrity": "sha512-WPrTHFngvN081RY+dJPneKQLwnOFD60OMCOQGmmSHfCW0f4ujPMzzhwWU1gcSwXPWXz5O+8cBiiCaxAbJU7kAg==",
+      "license": "MIT",
       "bin": {
         "stencil": "bin/stencil"
       },

--- a/alquileres-app/src/app/components/header/header.component.html
+++ b/alquileres-app/src/app/components/header/header.component.html
@@ -1,5 +1,4 @@
 <div class="wrapper">
-  <!-- <ion-buttons mode="ios" slot="start" class="ion-hide-lg-up"> -->
   <ion-buttons mode="ios" slot="start" class="mobile-menu">
     <ion-menu-button style="color: #000; transform: translateY(6px);"></ion-menu-button>
   </ion-buttons>

--- a/alquileres-app/src/app/components/header/header.component.html
+++ b/alquileres-app/src/app/components/header/header.component.html
@@ -1,9 +1,10 @@
 <div class="wrapper">
-  <ion-buttons mode="ios" slot="start" class="ion-hide-lg-up">
+  <!-- <ion-buttons mode="ios" slot="start" class="ion-hide-lg-up"> -->
+  <ion-buttons mode="ios" slot="start" class="mobile-menu">
     <ion-menu-button style="color: #000; transform: translateY(6px);"></ion-menu-button>
   </ion-buttons>
   <h1 style="cursor: pointer;" (click)="navigateTo('/')">AlquileresApp</h1>
-  <div class="buttons ion-hide-sm-down">
+  <div class="buttons desktop-menu">
     <ion-button mode="ios" (click)="navigateTo('/')" fill="clear">Buscar alquileres</ion-button>
     <ion-button mode="ios" (click)="navigateTo('/categories')" fill="clear">Categorias</ion-button>
     <ion-button mode="ios" (click)="navigateTo('/categories', { localidades: true })" fill="clear">Lugares para alquilar</ion-button>

--- a/alquileres-app/src/app/components/header/header.component.scss
+++ b/alquileres-app/src/app/components/header/header.component.scss
@@ -48,3 +48,15 @@ ion-button[fill="outline"] {
     font-weight: bold;
     margin-right: 10px;
 }
+
+@media(max-width: 991px) {
+    .desktop-menu {
+        display: none;
+    }
+}
+
+@media(min-width: 992px) {
+    .mobile-menu {
+        display: none;
+    }
+}


### PR DESCRIPTION
- Se reemplazaron las clases ion-hide-lg-up y ion-hide-sm-down por mobile-menu y deskop-menu respectivamente
- Estas clases están controladas por las variables de diseño responsive de Ionic 
- En el espacio entre 576px (sm) y 992 (lg), se mostraba el menú duplicado